### PR TITLE
Add BrcmPatchRAM

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -19,6 +19,15 @@
       "URL": "https://github.com/acidanthera/AppleALC"
     },
     {
+      "Debug File": "build/Products/Debug/*.zip",
+      "Desc": "An open source kernel extension which applies PatchRAM updates for Broadcom RAMUSB based devices",
+      "Lilu": false,
+      "MacKernelSDK": true,
+      "Name": "BrcmPatchRAM",
+      "Release File": "build/Products/Release/*.zip",
+      "URL": "https://github.com/acidanthera/BrcmPatchRAM"
+    },
+    {
       "Debug File": "build/Debug/*.zip",
       "Desc": "An open source kernel extension providing patches for IOBluetoothFamily.",
       "Lilu": true,

--- a/plugins.json
+++ b/plugins.json
@@ -19,6 +19,10 @@
       "URL": "https://github.com/acidanthera/AppleALC"
     },
     {
+      "Build Opts": [
+        "-target",
+        "Package"
+      ],
       "Debug File": "build/Products/Debug/*.zip",
       "Desc": "An open source kernel extension which applies PatchRAM updates for Broadcom RAMUSB based devices",
       "Lilu": false,
@@ -262,6 +266,10 @@
       "URL": "https://github.com/Mieze/RTL8111_driver_for_OS_X"
     },
     {
+      "Build Opts": [
+        "-target",
+        "Package"
+      ],
       "Debug File": "build/Debug/*.zip",
       "Desc": "advanced Apple SMC emulator in the kernel",
       "Lilu": true,


### PR DESCRIPTION
Now BrcmPatchRAM can be built just like other plugins (https://github.com/acidanthera/BrcmPatchRAM/pull/5)